### PR TITLE
feat: sticky menu

### DIFF
--- a/src/V2/Components/Menu/LargeScreenMenu.tsx
+++ b/src/V2/Components/Menu/LargeScreenMenu.tsx
@@ -38,7 +38,7 @@ const LargeScreenMenu = () => {
     };
 
     return(
-        <div className="w-[90%] lg:w-[80%] h-[54px] flex flex-row justify-center items-center border-b-[1px] px-[24px]">
+        <div className="sticky top-0 w-[90%] lg:w-[80%] h-[54px] flex flex-row justify-center items-center border-b-[1px] px-[24px]">
             <div className="text-[24px] font-bold w-full h-full flex items-end">
                 Taskly
             </div>


### PR DESCRIPTION
Users can now be able to use the menu as they scroll through the list of tasks. This has been made possible by sticking the menu at the top of the page.